### PR TITLE
Do not change environment if crc error in all available U-Boot environments

### DIFF
--- a/handlers/fw_env.c
+++ b/handlers/fw_env.c
@@ -1022,8 +1022,8 @@ int fw_env_open(void)
 	if (!HaveRedundEnv) {
 		if (!crc0_ok) {
 			fprintf (stderr,
-				"Warning: Bad CRC, using default environment\n");
-			memcpy(environment.data, default_environment, sizeof default_environment);
+				"Warning: Bad CRC: not setting any environment data ...\n");
+			return -1;
 		}
 	} else {
 		flag0 = *environment.flags;
@@ -1071,10 +1071,8 @@ int fw_env_open(void)
 			dev_current = 1;
 		} else if (!crc0_ok && !crc1_ok) {
 			fprintf (stderr,
-				"Warning: Bad CRC, using default environment\n");
-			memcpy (environment.data, default_environment,
-				sizeof default_environment);
-			dev_current = 0;
+			        "Warning: Bad CRC: not setting any environment data ...\n");
+            return -1;
 		} else {
 			switch (environment.flag_scheme) {
 			case FLAG_BOOLEAN:


### PR DESCRIPTION
swupdate tries to write a variable to the actual U-Boot environment. If there is no such environment, a mostly empty default environment is written + the variable. This behaviour breaks the compiled in default environment setting in U-Boot and a reboot will most propably not work as expected.

Signed-off-by: Daniel Schnell daniel.schnell.extern@ifm.com
