### PR TITLE
Add device_id parsing in xmlparser.lua

### DIFF
--- a/examples/lua-xml/xmlparser.lua
+++ b/examples/lua-xml/xmlparser.lua
@@ -108,6 +108,9 @@ function xmlparser(name, device)
 				if (streams[i]["attr"]["dest"]) then
 					img[count]["dest"] = streams[i]["attr"]["dest"]
 				end
+				if (streams[i]["attr"]["device_id"]) then
+					img[count]["device_id"] = streams[i]["attr"]["device_id"]
+				end
 
 			end
 		end


### PR DESCRIPTION
This adds the attribute device_id in xml image definitions..

Signed-off-by: Daniel Schnell daniel.schnell.extern@ifm.com
