### PR TITLE
Flush output stream for notifications

### DIFF
--- a/core/notifier.c
+++ b/core/notifier.c
@@ -49,7 +49,7 @@ struct notify_elem {
 
 STAILQ_HEAD(notifylist, notify_elem);
 
-static struct notifylist clients; 
+static struct notifylist clients;
 
 int register_notifier(notifier client)
 {
@@ -102,6 +102,7 @@ static void console_notifier (RECOVERY_STATUS status, int error, const char *msg
 	}
 
 	fprintf(stdout, "[NOTIFY] : %s %s\n", current, msg ? msg : "");
+	fflush(stdout);
 }
 
 void notify_init(void)


### PR DESCRIPTION
`fprintf()` does buffered I/O. Without flushing the `stdout` stream a parent process (in my example a Node.js application) using `swupdate` as a child will not receive a notification until the buffer is full or swupdate exits.

My editor automatically removed a trailing whitespace.