### PR TITLE
checksum verification

### DIFF
--- a/archival/Config.src
+++ b/archival/Config.src
@@ -21,6 +21,16 @@ config CPIO
 	  Unless you have a specific application which requires cpio, you
 	  should probably say N here.
 
+config CPIO_VERIFY_CHECKSUM_BEFORE_UPDATE
+	bool "cpio: verify checksum before update"
+	default y
+	help
+	  If activated all of the cpio archive's checksums are verified before
+	  starting the update. Otherwise the checksums are verified while/after
+	  the update installation.
+	  As the pre-installation checksum verification takes some time, this
+	  behavior can be deactivated
+
 config GUNZIP
 	bool "gunzip"
 	default y

--- a/core/swupdate.c
+++ b/core/swupdate.c
@@ -219,7 +219,11 @@ static int install_from_file(char *fname)
 		exit(1);
 	}
 
-	cpio_scan(fdsw, &swcfg, pos);
+	pos = cpio_scan(fdsw, &swcfg, pos);
+	if (pos < 0) {
+		close(fdsw);
+		exit(1);
+	}
 
 	/*
 	 * Check if all files described in sw-description

--- a/handlers/raw_handler.c
+++ b/handlers/raw_handler.c
@@ -57,6 +57,11 @@ static int install_raw_image(struct img_type *img,
 	}
 	
 	ret = copyfile(img->fdin, fdout, img->size, &offset, 0, img->compressed, &checksum);
+	if ((uint32_t)(img->checksum) != checksum)
+	{
+		TRACE("Checkum verification failed: %x != %x\n", img->checksum, checksum);
+		ret = -1;
+	}
 	close(fdout);
 	return ret;
 }

--- a/include/util.h
+++ b/include/util.h
@@ -119,6 +119,7 @@ int copyfile(int fdin, int fdout, int nbytes, unsigned long *offs,
 off_t extract_sw_description(int fd);
 off_t extract_next_file(int fd, int fdout, off_t start, int compressed);
 int openfileoutput(const char *filename);
+int calc_checksum(int fdin, int nbytes, unsigned long offset, uint32_t *checksum);
 
 int register_notifier(notifier client);
 void notify(RECOVERY_STATUS status, int error, const char *msg);


### PR DESCRIPTION
Looks like I'm the only one with bad luck and an usb flash drive which reliably corrupts data...
This patch adds checksum verification for the raw_handler and an optional checksum verification for the whole archive before the installation of the update starts.