### PR TITLE
Kbuild: compatibility with make-4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,15 +169,15 @@ include $(srctree)/scripts/Kbuild.include
 
 # Make variables (CC, etc...)
 
-AS		?= $(CROSS_COMPILE)as
-LD		?= $(CROSS_COMPILE)gcc
-CC		?= $(CROSS_COMPILE)gcc
-CPP		?= $(CC) -E
-AR		?= $(CROSS_COMPILE)ar
-NM		?= $(CROSS_COMPILE)nm
-STRIP		?= $(CROSS_COMPILE)strip
-OBJCOPY		?= $(CROSS_COMPILE)objcopy
-OBJDUMP		?= $(CROSS_COMPILE)objdump
+AS		= $(CROSS_COMPILE)as
+LD		= $(CROSS_COMPILE)gcc
+CC		= $(CROSS_COMPILE)gcc
+CPP		= $(CC) -E
+AR		= $(CROSS_COMPILE)ar
+NM		= $(CROSS_COMPILE)nm
+STRIP		= $(CROSS_COMPILE)strip
+OBJCOPY		= $(CROSS_COMPILE)objcopy
+OBJDUMP		= $(CROSS_COMPILE)objdump
 AWK		= awk
 INSTALLKERNEL  := installkernel
 PERL		= perl


### PR DESCRIPTION
make 4.1 parses MAKEFLAGS later than in make 3.x, which breaks
'?=' assignment on variables with builtin assignments when
MAKEFLAGS adds -R flag

https://savannah.gnu.org/bugs/?45211

Switch to using normal '=' assignments, which just means that
non-standard values of these variables will need to be passed
on the command line instead of just exported, i.e.

  # won't override any more
  export CC=my-special-cc ; make

  # this is still ok
  make CC=my-special-cc

Note that plain '=' is already how the linux kernel Makefile sets
these same variables, so this is more consistent with kernel Kbuild.

Signed-off-by: S. Lockwood-Childs sjl@vctlabs.com
