### PR TITLE
Changes to support extracting file permissions, ownership, time, etc

### DIFF
--- a/handlers/archive_handler.c
+++ b/handlers/archive_handler.c
@@ -193,6 +193,23 @@ static int install_archive_image(struct img_type *img,
 			img->fname, path);
 
 		tf.flags = 0;
+        if  (img->extract_time) {
+            tf.flags |= ARCHIVE_EXTRACT_TIME;
+		    TRACE("extract time attributes");
+        }
+        if (img->extract_perm) {
+            tf.flags |= ARCHIVE_EXTRACT_PERM;
+		    TRACE("extract permission attributes");
+        }
+        if (img->extract_acl) {
+            tf.flags |= ARCHIVE_EXTRACT_ACL;
+		    TRACE("extract ACL attributes");
+        }
+        if (img->extract_fflags) {
+            tf.flags |= ARCHIVE_EXTRACT_FFLAGS;
+		    TRACE("extract fflags attributes");
+        }
+		TRACE("extract flags = 0x%02X", tf.flags);
 
 		ret = pthread_create(&extract_thread, &attr, extract, &tf);
 		if (ret) {

--- a/handlers/archive_handler.c
+++ b/handlers/archive_handler.c
@@ -193,22 +193,22 @@ static int install_archive_image(struct img_type *img,
 			img->fname, path);
 
 		tf.flags = 0;
-        if  (img->extract_time) {
-            tf.flags |= ARCHIVE_EXTRACT_TIME;
-		    TRACE("extract time attributes");
-        }
-        if (img->extract_perm) {
-            tf.flags |= ARCHIVE_EXTRACT_PERM;
-		    TRACE("extract permission attributes");
-        }
-        if (img->extract_acl) {
-            tf.flags |= ARCHIVE_EXTRACT_ACL;
-		    TRACE("extract ACL attributes");
-        }
-        if (img->extract_fflags) {
-            tf.flags |= ARCHIVE_EXTRACT_FFLAGS;
-		    TRACE("extract fflags attributes");
-        }
+		if  (img->extract_time) {
+			tf.flags |= ARCHIVE_EXTRACT_TIME;
+			TRACE("extract time attributes");
+		}
+		if (img->extract_perm) {
+			tf.flags |= ARCHIVE_EXTRACT_PERM;
+			TRACE("extract permission attributes");
+		}
+		if (img->extract_acl) {
+			tf.flags |= ARCHIVE_EXTRACT_ACL;
+			TRACE("extract ACL attributes");
+		}
+		if (img->extract_fflags) {
+			tf.flags |= ARCHIVE_EXTRACT_FFLAGS;
+			TRACE("extract fflags attributes");
+		}
 		TRACE("extract flags = 0x%02X", tf.flags);
 
 		ret = pthread_create(&extract_thread, &attr, extract, &tf);

--- a/include/swupdate.h
+++ b/include/swupdate.h
@@ -46,6 +46,10 @@ struct img_type {
 	int compressed;
 	int is_script;
 	int is_partitioner;
+    int extract_time;       /* preserve time of file in archive */
+    int extract_perm;       /* preserve file permissions - uid, gid */
+    int extract_acl;        /* preserve acl info of file in archive */
+    int extract_fflags;     /* preserve ff_flags - what is this? */
 	long long partsize;
 	int fdin;	/* Used for streaming file */
 	off_t offset;	/* offset in cpio file */

--- a/include/swupdate.h
+++ b/include/swupdate.h
@@ -46,10 +46,10 @@ struct img_type {
 	int compressed;
 	int is_script;
 	int is_partitioner;
-    int extract_time;       /* preserve time of file in archive */
-    int extract_perm;       /* preserve file permissions - uid, gid */
-    int extract_acl;        /* preserve acl info of file in archive */
-    int extract_fflags;     /* preserve ff_flags - what is this? */
+	int extract_time;       /* preserve time of file in archive */
+	int extract_perm;       /* preserve file permissions - uid, gid */
+	int extract_acl;        /* preserve acl info of file in archive */
+	int extract_fflags;     /* preserve ff_flags - what is this? */
 	long long partsize;
 	int fdin;	/* Used for streaming file */
 	off_t offset;	/* offset in cpio file */

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -630,6 +630,11 @@ static void parse_files(parsertype p, void *cfg, struct swupdate_cfg *swcfg)
 			strcpy(file->type, "rawfile");
 		}
 		get_field(p, elem, "compressed", &file->compressed);
+		get_field(p, elem, "extract_time", &file->extract_time);
+		get_field(p, elem, "extract_perm", &file->extract_perm);
+		get_field(p, elem, "extract_acl", &file->extract_acl);
+		get_field(p, elem, "extract_fflags", &file->extract_fflags);
+
 		TRACE("Found %sFile: %s --> %s (%s)\n",
 			file->compressed ? "compressed " : "",
 			file->fname,


### PR DESCRIPTION
Hi Stefano,

I've made changes to support extracting file permissions, ownership, time, etc.
The code looks ok to me, however the extracted files do not have the expected attributes.  i.e. everything is still owned by root, times are not preserved, etc.

I was referring to the `A Complete Extractor` section of this [page](https://github.com/libarchive/libarchive/wiki/Examples).

Hopefully you can see if there is something I may have missed.

Thanks,
Brendan.
