### PR TITLE
Fixed a possible memory leak

### DIFF
--- a/core/cpio_utils.c
+++ b/core/cpio_utils.c
@@ -198,7 +198,7 @@ int copyfile(int fdin, void *out, unsigned int nbytes, unsigned long *offs, unsi
 	while (nbytes > 0) {
 		size = (nbytes < BUFF_SIZE ? nbytes : BUFF_SIZE);
 
-		if ((ret = fill_buffer(fdin, in, size, offs, checksum, dgst) < 0)) {
+		if ((ret = fill_buffer(fdin, in, size, offs, checksum, dgst)) < 0) {
 			goto copyfile_exit;
 		}
 

--- a/corelib/installer.c
+++ b/corelib/installer.c
@@ -449,7 +449,7 @@ int postupdate(struct swupdate_cfg *swcfg, const char *info)
 {
 	swupdate_progress_done(info);
 
-	if ((swcfg) && (swcfg->globals.postupdatecmd) &&
+	if ((swcfg) &&
 	    (strnlen(swcfg->globals.postupdatecmd,
 		     SWUPDATE_GENERAL_STRING_SIZE) > 0)) {
 		DEBUG("Executing post-update command '%s'",

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -427,7 +427,7 @@ static int parse_images(parsertype p, void *cfg, struct swupdate_cfg *swcfg, lua
 		get_hash_value(p, elem, image->sha256);
 
 		/* convert the offset handling multiplicative suffixes */
-		if (seek_str != NULL && strnlen(seek_str, MAX_SEEK_STRING_SIZE) != 0) {
+		if (strnlen(seek_str, MAX_SEEK_STRING_SIZE) != 0) {
 			errno = 0;
 			image->seek = ustrtoull(seek_str, &endp, 0);
 			if (seek_str == endp || (image->seek == ULLONG_MAX && \

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -253,6 +253,7 @@ static int parse_partitions(parsertype p, void *cfg, struct swupdate_cfg *swcfg)
 
 		if (!strlen(partition->volname) || !strlen(partition->device)) {
 			ERROR("Partition incompleted in description file");
+			free(partition);
 			return -1;
 		}
 
@@ -432,6 +433,7 @@ static int parse_images(parsertype p, void *cfg, struct swupdate_cfg *swcfg, lua
 			if (seek_str == endp || (image->seek == ULLONG_MAX && \
 					errno == ERANGE)) {
 				ERROR("offset argument: ustrtoull failed");
+				free(image);
 				return -1;
 			}
 		} else


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:
swupdate/parser/parser.c 256 err V773 The function was exited without releasing the 'partition' pointer. A memory leak is possible.
swupdate/parser/parser.c 435 err V773 The function was exited without releasing the 'image' pointer. A memory leak is possible.
swupdate/parser/parser.c 429     warn    V600 Consider inspecting the condition. The 'seek_str' pointer is always not equal to NULL.
swupdate/core/cpio_utils.c       201     err     V593 Consider reviewing the expression of the 'A = B < C' kind. The expression is calculated as following: 'A = (B < C)'.
swupdate/corelib/installer.c     452     warn    V600 Consider inspecting the condition. The 'swcfg->globals.postupdatecmd' pointer is always not equal to NULL.