### PR TITLE
downloader: add option to send Basic Auth

### DIFF
--- a/doc/source/swupdate.rst
+++ b/doc/source/swupdate.rst
@@ -534,6 +534,8 @@ Command line parameters
 | -t <timeout>| integer  | Timeout for connection lost when           |
 |             |          | downloading                                |
 +-------------+----------+--------------------------------------------+
+| -a <usr:pwd>| string   | Send user and password for Basic Auth      |
++-------------+----------+--------------------------------------------+
 
 
 systemd Integration


### PR DESCRIPTION
This option is needed if a update is protected by username / password to avoid that anybody can download this file.

This method is used by Cumulocity infrastructure for example to deploy update.