### PR TITLE
Fix compilation error

### DIFF
--- a/include/sslapi.h
+++ b/include/sslapi.h
@@ -70,6 +70,7 @@ struct swupdate_digest {
 #endif
 
 #else
+struct swupdate_digest;
 #define swupdate_crypto_init()
 #define AES_BLOCK_SIZE	16
 #endif


### PR DESCRIPTION
The commit 15a08c0 has introduced a compilation error when the following
condition is met:

	!defined(CONFIG_HASH_VERIFY) && !defined(CONFIG_ENCRYPTED_IMAGES) && !defined(CONFIG_SURICATTA_SSL)

In that situation the structure swupdate_digest is never defined and the
compiler raises the following warnings and errors:

	  CC      core/swupdate.o
	In file included from core/swupdate.c:43:0:
	include/sslapi.h:94:47: warning: ‘struct swupdate_digest’ declared inside parameter list will not be visible outside of this definition or declaration
	 static inline int swupdate_HASH_update(struct swupdate_digest *dgst,
	                                               ^~~~~~~~~~~~~~~
	include/sslapi.h:96:47: warning: ‘struct swupdate_digest’ declared inside parameter list will not be visible outside of this definition or declaration
	 static inline int swupdate_HASH_update(struct swupdate_digest *dgst,
	                                               ^~~~~~~~~~~~~~~
	include/sslapi.h:96:19: error: conflicting types for ‘swupdate_HASH_update’
	 static inline int swupdate_HASH_update(struct swupdate_digest *dgst,
	                   ^~~~~~~~~~~~~~~~~~~~
	include/sslapi.h:94:19: note: previous declaration of ‘swupdate_HASH_update’ was here
	 static inline int swupdate_HASH_update(struct swupdate_digest *dgst,
	                   ^~~~~~~~~~~~~~~~~~~~
	include/sslapi.h:104:46: warning: ‘struct swupdate_digest’ declared inside parameter list will not be visible outside of this definition or declaration
	 static inline int swupdate_HASH_final(struct swupdate_digest *dgst,
	                                              ^~~~~~~~~~~~~~~
	include/sslapi.h:106:46: warning: ‘struct swupdate_digest’ declared inside parameter list will not be visible outside of this definition or declaration
	 static inline int swupdate_HASH_final(struct swupdate_digest *dgst,
	                                              ^~~~~~~~~~~~~~~
	include/sslapi.h:106:19: error: conflicting types for ‘swupdate_HASH_final’
	 static inline int swupdate_HASH_final(struct swupdate_digest *dgst,
	                   ^~~~~~~~~~~~~~~~~~~
	include/sslapi.h:104:19: note: previous declaration of ‘swupdate_HASH_final’ was here
	 static inline int swupdate_HASH_final(struct swupdate_digest *dgst,
	                   ^~~~~~~~~~~~~~~~~~~

The argument is not necessary and can be safely forwarded.

Signed-off-by: Gaël PORTAY <gael.portay@savoirfairelinux.com>