### PR TITLE
cpio_utils: verify also image hash while scanning cpio

### DIFF
--- a/core/cpio_utils.c
+++ b/core/cpio_utils.c
@@ -647,12 +647,10 @@ int cpio_scan(int fd, struct swupdate_cfg *cfg, off_t start)
 			return 0;
 		}
 
-		SEARCH_FILE(struct img_type, cfg->images,
-			file_listed, start);
-		SEARCH_FILE(struct img_type, cfg->scripts,
-			file_listed, start);
-		SEARCH_FILE(struct img_type, cfg->bootscripts,
-			file_listed, start);
+		struct img_type *img = NULL;
+		SEARCH_FILE(img, cfg->images, file_listed, start);
+		SEARCH_FILE(img, cfg->scripts, file_listed, start);
+		SEARCH_FILE(img, cfg->bootscripts, file_listed, start);
 
 		TRACE("Found file:\n\tfilename %s\n\tsize %lu\n\t%s\n",
 			fdh.filename,
@@ -660,10 +658,11 @@ int cpio_scan(int fd, struct swupdate_cfg *cfg, off_t start)
 			file_listed ? "REQUIRED" : "not required");
 
 		/*
-		 * use copyfile for checksum verification, as we skip file
+		 * use copyfile for checksum and hash verification, as we skip file
 		 * we do not have to provide fdout
 		 */
-		if (copyfile(fd, NULL, fdh.size, &offset, 0, 1, 0, &checksum, NULL, 0, NULL) != 0) {
+		if (copyfile(fd, NULL, fdh.size, &offset, 0, 1, 0, &checksum, img ? img->sha256 : NULL,
+				0, NULL) != 0) {
 			ERROR("invalid archive\n");
 			return -1;
 		}

--- a/include/swupdate.h
+++ b/include/swupdate.h
@@ -129,18 +129,20 @@ struct swupdate_cfg {
 	const char *embscript;
 };
 
-#define SEARCH_FILE(type, list, found, offs) do { \
+#define SEARCH_FILE(img, list, found, offs) do { \
 	if (!found) { \
-		type *p; \
-		for (p = list.lh_first; p != NULL; \
-			p = p->next.le_next) { \
-			if (strcmp(p->fname, fdh.filename) == 0) { \
+		for (img = list.lh_first; img != NULL; \
+			img = img->next.le_next) { \
+			if (strcmp(img->fname, fdh.filename) == 0) { \
 				found = 1; \
-				p->offset = offs; \
-				p->provided = 1; \
-				p->size = fdh.size; \
+				img->offset = offs; \
+				img->provided = 1; \
+				img->size = fdh.size; \
+				break; \
 			} \
 		} \
+		if (!found) \
+			img = NULL; \
 	} \
 } while(0)
 


### PR DESCRIPTION
When update from local file is performed, files hashes are verified only during cpio_utils::copyfile called from fs handler and not before. If fs handler (ubi) is not extracting file to ram before writing, unsigned file can be write to fs.

Patch was ported from older version and wasn't tested on current master.

Signed-off-by: Martin Geier <martin.geier@streamunlimited.com>