### PR TITLE
core: ustrtoull: convert zero length strings to 0

### DIFF
--- a/core/util.c
+++ b/core/util.c
@@ -484,11 +484,11 @@ unsigned long long ustrtoull(const char *cp, unsigned int base)
 	errno = 0;
 	char *endp = NULL;
 
-	unsigned long long result = strtoull(cp, &endp, base);
-
 	if (strnlen(cp, MAX_SEEK_STRING_SIZE) == 0) {
 		return 0;
 	}
+
+	unsigned long long result = strtoull(cp, &endp, base);
 
 	if (cp == endp || (result == ULLONG_MAX && errno == ERANGE)) {
 		errno = ERANGE;


### PR DESCRIPTION
Without this change, parse_common_attributes() can not deal with an empty offset value.