### PR TITLE
examples: client: fix reading file from stdin

### DIFF
--- a/tools/client.c
+++ b/tools/client.c
@@ -38,7 +38,7 @@ static void usage(void) {
 }
 
 char buf[256];
-int fd;
+int fd = STDIN_FILENO;
 int verbose = 1;
 
 pthread_mutex_t mymutex;
@@ -95,7 +95,7 @@ static int end(RECOVERY_STATUS status)
  */
 static int send_file(const char* filename) {
 	int rc;
-	if ( (fd = open(filename, O_RDONLY)) < 0) {
+	if (filename && (fd = open(filename, O_RDONLY)) < 0) {
 		printf ("I cannot open %s\n", filename);
 		return 1;
 	}


### PR DESCRIPTION
I suggested that reading a file from stdin is in the client implemented because of the check and special handling for parameter "-" in the main function.
My suggestion wasn´t true and open is called with "NULL" as filename instead of using "STDIN_FILENO" (=0) as file descriptor in the function send_file.

This pr fixes this issue.

I prefer to explicit set the file descriptor initially to "STDIN_FILENO" (=0) instead on relying on global variable initialization, as it make this behavior more clear.

Signed-off-by: Johann Neuhauser <jneuhauser@dh-electronics.de>