### PR TITLE
swupdate-progress: make sure bar array is 0-terminated (buffer overflow)

### DIFF
--- a/tools/swupdate-progress.c
+++ b/tools/swupdate-progress.c
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
 	int psplash_ok = 0;
 	unsigned int curstep = 0;
 	unsigned int percent = 0;
-	char bar[60];
+	char bar[61];
 	unsigned int filled_len;
 	int opt_c = 0;
 	int opt_w = 0;
@@ -298,6 +298,7 @@ int main(int argc, char **argv)
 
 		memset(bar,'=', filled_len);
 		memset(&bar[filled_len], '-', sizeof(bar) - filled_len - 1);
+                bar[sizeof(bar)-1] = 0;
 
 		fprintf(stdout, "[ %.60s ] %d of %d %d%% (%s)\r",
 			bar,


### PR DESCRIPTION
The bar filling was based on the assumption that there are sizeof(bar) - 1
characters, but terminating 0 was never set. The bar array was 60 chars,
and the fprintf formatting string expected to find 60 chars, thus printing one
garbage char, and the missing 0-terminator was causing the app to crash.

The commit increases the size of bar by 1, and 0-terminates it.

Signed-off-by: Tomas Frydrych <tomas@tomtain.com>