### PR TITLE
add non blocking progress-ipc support

### DIFF
--- a/include/flash.h
+++ b/include/flash.h
@@ -10,8 +10,8 @@
 #define _FLASH_PART_H
 
 #include <stdint.h>
-#include <libmtd.h>
-#include <libubi.h>
+#include <mtd/libmtd.h>
+#include <mtd/libubi.h>
 #include "bsdqueue.h"
 
 #define DEFAULT_CTRL_DEV "/dev/ubi_ctrl"

--- a/ipc/progress_ipc.c
+++ b/ipc/progress_ipc.c
@@ -7,7 +7,6 @@
 
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <errno.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -79,16 +78,11 @@ int progress_ipc_connect(bool reconnect)
 
 int progress_ipc_receive(int *connfd, struct progress_msg *msg) {
 	int ret = read(*connfd, msg, sizeof(*msg));
-
-	if (ret == -1 && errno == EAGAIN)
-		return 0;
-
 	if (ret != sizeof(*msg)) {
 		fprintf(stdout, "Connection closing..\n");
 		close(*connfd);
 		*connfd = -1;
 		return -1;
 	}
-
 	return ret;
 }

--- a/ipc/progress_ipc.c
+++ b/ipc/progress_ipc.c
@@ -7,6 +7,7 @@
 
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <errno.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -78,11 +79,16 @@ int progress_ipc_connect(bool reconnect)
 
 int progress_ipc_receive(int *connfd, struct progress_msg *msg) {
 	int ret = read(*connfd, msg, sizeof(*msg));
+
+	if (ret == -1 && errno == EAGAIN)
+		return 0;
+
 	if (ret != sizeof(*msg)) {
 		fprintf(stdout, "Connection closing..\n");
 		close(*connfd);
 		*connfd = -1;
 		return -1;
 	}
+
 	return ret;
 }


### PR DESCRIPTION
Currently when setting ipc to non blocking mode on progress-ipc, progress_ipc_receive routine will shutdown the ipc connection because of EAGAIN error. This patch should allow using progress_ipc_receive with non blocking