### PR TITLE
Support script handlers implemented in Lua

### DIFF
--- a/core/installer.c
+++ b/core/installer.c
@@ -200,7 +200,7 @@ static int run_prepost_scripts(struct imglist *list, script_fn type)
 			continue;
 		hnd = find_handler(img);
 		if (hnd) {
-			ret = hnd->installer(img, &type);
+			ret = hnd->installer(img, hnd->data, type);
 			if (ret)
 				return ret;
 		}
@@ -231,7 +231,7 @@ int install_single_image(struct img_type *img, bool dry_run)
 	swupdate_progress_inc_step(img->fname, hnd->desc);
 
 	/* TODO : check callback to push results / progress */
-	ret = hnd->installer(img, hnd->data);
+	ret = hnd->installer(img, hnd->data, NONE);
 	if (ret != 0) {
 		TRACE("Installer for %s not successful !",
 			hnd->desc);

--- a/corelib/lua_interface.c
+++ b/corelib/lua_interface.c
@@ -1098,7 +1098,19 @@ static int l_handler_wrapper(struct img_type *img, void *data,
 	lua_rawgeti(gL, LUA_REGISTRYINDEX, l_func_ref );
 	image2table(gL, img);
 
-	if (LUA_OK != (res = lua_pcall(gL, 1, 1, 0))) {
+	switch (scriptfn) {
+	case PREINSTALL:
+		lua_pushstring(gL, "preinst");
+		break;
+	case POSTINSTALL:
+		lua_pushstring(gL, "postinst");
+		break;
+	default:
+		lua_pushnil(gL);
+		break;
+	}
+
+	if (LUA_OK != (res = lua_pcall(gL, 2, 1, 0))) {
 		ERROR("Error %d while executing the Lua callback: %s",
 			  res, lua_tostring(gL, -1));
 		return -1;

--- a/corelib/lua_interface.c
+++ b/corelib/lua_interface.c
@@ -1070,7 +1070,9 @@ static lua_State *gL = NULL;
  * @param data [in] pointer to the index in the Lua registry for the function
  * @return This function returns 0 if successful and -1 if unsuccessful.
  */
-static int l_handler_wrapper(struct img_type *img, void *data) {
+static int l_handler_wrapper(struct img_type *img, void *data,
+			     script_fn __attribute__ ((__unused__)) scriptfn)
+{
 	int res = 0;
 	lua_Number result;
 	int l_func_ref;
@@ -1175,7 +1177,7 @@ static int l_call_handler(lua_State *L)
 		ret = 1;
 		goto call_handler_exit;
 	}
-	if ((hnd->installer(&img, hnd->data)) != 0) {
+	if ((hnd->installer(&img, hnd->data, NONE)) != 0) {
 		if (asprintf(&msg, "Executing handler %s failed!", hnd->desc) == -1) {
 			msg = NULL;
 		}

--- a/corelib/lua_interface.c
+++ b/corelib/lua_interface.c
@@ -1036,6 +1036,7 @@ static int luaopen_swupdate(lua_State *L)
 		lua_push_enum(L, "SCRIPT_HANDLER", SCRIPT_HANDLER);
 		lua_push_enum(L, "BOOTLOADER_HANDLER", BOOTLOADER_HANDLER);
 		lua_push_enum(L, "PARTITION_HANDLER", PARTITION_HANDLER);
+		lua_push_enum(L, "NO_DATA_HANDLER", NO_DATA_HANDLER);
 		lua_push_enum(L, "ANY_HANDLER", ANY_HANDLER);
 		lua_settable(L, -3);
 

--- a/doc/source/handlers.rst
+++ b/doc/source/handlers.rst
@@ -293,7 +293,7 @@ In analogy to C handlers, the prototype for a Lua handler is
 
 ::
 
-        function lua_handler(image)
+        function lua_handler(image, scriptfn)
             ...
         end
 
@@ -305,6 +305,10 @@ Note that dashes in the attributes' names are replaced with
 underscores for the Lua domain to make them idiomatic, e.g.,
 ``installed-directly`` becomes ``installed_directly`` in the
 Lua domain.
+
+For a script handler, ``scriptfn`` is either ``"preinst"`` or
+``"postinst"``.  For other handlers it is ``nil``, and does not need
+to be declared as a parameter.
 
 To register a Lua handler, the ``swupdate`` module provides the
 ``swupdate.register_handler()`` method that takes the handler's

--- a/doc/source/handlers.rst
+++ b/doc/source/handlers.rst
@@ -56,7 +56,8 @@ The prototype for the callback is:
 ::
 
 	int my_handler(struct img_type *img,
-		void __attribute__ ((__unused__)) *data)
+		void __attribute__ ((__unused__)) *data,
+		script_fn __attribute__ ((__unused__)) scriptfn)
 
 
 The most important parameter is the pointer to a struct img_type. It describes

--- a/handlers/archive_handler.c
+++ b/handlers/archive_handler.c
@@ -210,7 +210,8 @@ out:
 }
 
 static int install_archive_image(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	char path[255];
 	int fdout = -1;

--- a/handlers/boot_handler.c
+++ b/handlers/boot_handler.c
@@ -25,7 +25,8 @@ static void uboot_handler(void);
 static void boot_handler(void);
 
 static int install_boot_environment(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	int ret;
 	int fdout;

--- a/handlers/delta_handler.c
+++ b/handlers/delta_handler.c
@@ -869,7 +869,8 @@ static bool copy_existing_chunks(zckChunk **dstChunk, struct hnd_priv *priv)
  * Handler entry point
  */
 static int install_delta(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	struct hnd_priv *priv;
 	int ret = -1;

--- a/handlers/diskformat_handler.c
+++ b/handlers/diskformat_handler.c
@@ -15,7 +15,8 @@
 void diskformat_handler(void);
 
 static int diskformat(struct img_type *img,
-		      void __attribute__ ((__unused__)) *data)
+		      void __attribute__ ((__unused__)) *data,
+		      script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	int ret = 0;
 

--- a/handlers/diskpart_handler.c
+++ b/handlers/diskpart_handler.c
@@ -774,7 +774,8 @@ static void diskpart_unref_context(struct fdisk_context *cxt)
 }
 
 static int diskpart(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	char *lbtype = diskpart_get_lbtype(img);
 	struct dict_list *parts;

--- a/handlers/dummy_handler.c
+++ b/handlers/dummy_handler.c
@@ -19,7 +19,8 @@
 void dummy_handler(void);
 
 static int install_nothing(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	int ret;
 	int fdout;

--- a/handlers/flash_hamming1_handler.c
+++ b/handlers/flash_hamming1_handler.c
@@ -277,7 +277,8 @@ out:
 }
 
 static int install_flash_hamming_image(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	int mtdnum;
 

--- a/handlers/flash_handler.c
+++ b/handlers/flash_handler.c
@@ -335,7 +335,8 @@ static int flash_write_image(int mtdnum, struct img_type *img)
 }
 
 static int install_flash_image(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	int mtdnum;
 

--- a/handlers/lua_scripthandler.c
+++ b/handlers/lua_scripthandler.c
@@ -25,19 +25,15 @@
 
 static void lua_handler(void);
 
-static int start_lua_script(struct img_type *img, void *data)
+static int start_lua_script(struct img_type *img,
+			    void __attribute__ ((__unused__)) *data,
+			    script_fn scriptfn)
 {
 	int ret;
 	const char *fnname;
-	script_fn scriptfn;
 
 	const char* tmp = get_tmpdirscripts();
 	char filename[MAX_IMAGE_FNAME + strlen(tmp) + 2 + strlen(img->type_data)];
-
-	if (!data)
-		return -1;
-
-	scriptfn = *(script_fn *)data;
 
 	switch (scriptfn) {
 	case PREINSTALL:

--- a/handlers/raw_handler.c
+++ b/handlers/raw_handler.c
@@ -119,7 +119,8 @@ blkprotect_out:
 }
 
 static int install_raw_image(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	int ret;
 	int fdout;
@@ -150,7 +151,8 @@ static int install_raw_image(struct img_type *img,
 }
 
 static int copy_raw_image(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	int ret;
 	int fdout, fdin;
@@ -203,7 +205,8 @@ static int copy_raw_image(struct img_type *img,
 }
 
 static int install_raw_file(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	char path[255];
 	int fdout;

--- a/handlers/rdiff_handler.c
+++ b/handlers/rdiff_handler.c
@@ -219,7 +219,8 @@ static int apply_rdiff_chunk_cb(void *out, const void *buf, unsigned int len)
 }
 
 static int apply_rdiff_patch(struct img_type *img,
-							 void __attribute__((__unused__)) * data)
+			     void __attribute__((__unused__)) * data,
+			     script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	int ret = 0;
 

--- a/handlers/readback_handler.c
+++ b/handlers/readback_handler.c
@@ -26,12 +26,10 @@
 void readback_handler(void);
 static int readback_postinst(struct img_type *img);
 
-static int readback(struct img_type *img, void *data)
+static int readback(struct img_type *img,
+		    void __attribute__ ((__unused__)) *data,
+		    script_fn scriptfn)
 {
-	if (!data)
-		return -1;
-
-	script_fn scriptfn = *(script_fn *)data;
 	switch (scriptfn) {
 	case POSTINSTALL:
 		return readback_postinst(img);

--- a/handlers/remote_handler.c
+++ b/handlers/remote_handler.c
@@ -149,7 +149,8 @@ static int forward_data(void *request, const void *buf, unsigned int len)
 }
 
 static int install_remote_image(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	void *context = zmq_ctx_new();
 	void *request = zmq_socket (context, ZMQ_REQ);

--- a/handlers/shell_scripthandler.c
+++ b/handlers/shell_scripthandler.c
@@ -47,15 +47,11 @@ static int execute_shell_script(struct img_type *img, const char *fnname)
 	return ret;
 }
 
-static int start_shell_script(struct img_type *img, void *data)
+static int start_shell_script(struct img_type *img,
+			      void __attribute__ ((__unused__)) *data,
+			      script_fn scriptfn)
 {
 	const char *fnname;
-	script_fn scriptfn;
-
-	if (!data)
-		return -EINVAL;
-
-	scriptfn = *(script_fn *)data;
 
 	switch (scriptfn) {
 	case PREINSTALL:
@@ -72,15 +68,10 @@ static int start_shell_script(struct img_type *img, void *data)
 	return execute_shell_script(img, fnname);
 }
 
-static int start_preinstall_script(struct img_type *img, void *data)
+static int start_preinstall_script(struct img_type *img,
+				   void __attribute__ ((__unused__)) *data,
+				   script_fn scriptfn)
 {
-	script_fn scriptfn;
-
-	if (!data)
-		return -EINVAL;
-
-	scriptfn = *(script_fn *)data;
-
 	/*
 	 * Call only in case of preinstall
 	 */
@@ -90,15 +81,10 @@ static int start_preinstall_script(struct img_type *img, void *data)
 	return execute_shell_script(img, "");
 }
 
-static int start_postinstall_script(struct img_type *img, void *data)
+static int start_postinstall_script(struct img_type *img,
+				    void __attribute__ ((__unused__)) *data,
+				    script_fn scriptfn)
 {
-	script_fn scriptfn;
-
-	if (!data)
-		return -EINVAL;
-
-	scriptfn = *(script_fn *)data;
-
 	/*
 	 * Call only in case of postinstall
 	 */

--- a/handlers/ssbl_handler.c
+++ b/handlers/ssbl_handler.c
@@ -164,9 +164,10 @@ static int inline get_active_ssbl(struct ssbl_priv *padmins) {
 	return get_inactive_ssbl(padmins) == 1 ? 0 : 1;
 }
 
-static int ssbl_swap(struct img_type *img, void *data)
+static int ssbl_swap(struct img_type *img,
+		     void __attribute__ ((__unused__)) *data,
+		     script_fn scriptfn)
 {
-	script_fn scriptfn;
 	struct ssbl_priv admins[2];
 	struct ssbl_priv *pssbl;
 	struct proplist *entry;
@@ -174,11 +175,6 @@ static int ssbl_swap(struct img_type *img, void *data)
 	int fd;
 	struct flash_description *flash = get_flash_info();
 	char mtd_device[80];
-
-	if (!data)
-		return -EINVAL;
-
-	scriptfn = *(script_fn *)data;
 
 	/*
 	 * Call only in case of postinstall

--- a/handlers/swuforward_handler.c
+++ b/handlers/swuforward_handler.c
@@ -284,7 +284,8 @@ static int initialize_backchannel(struct hnd_priv *priv)
 }
 
 static int install_remote_swu(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	struct hnd_priv priv;
 	struct curlconn *conn, *tmp;

--- a/handlers/ubivol_handler.c
+++ b/handlers/ubivol_handler.c
@@ -388,7 +388,8 @@ static int wait_volume(struct img_type *img)
 }
 
 static int install_ubivol_image(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	struct flash_description *flash = get_flash_info();
 	struct ubi_part *ubivol;
@@ -429,7 +430,8 @@ static int install_ubivol_image(struct img_type *img,
 }
 
 static int adjust_volume(struct img_type *cfg,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	return resize_volume(cfg, cfg->partsize);
 }
@@ -450,9 +452,10 @@ static int ubi_volume_get_info(char *name, int *dev_num, int *vol_id)
 	return 0;
 }
 
-static int swap_volume(struct img_type *img, void *data)
+static int swap_volume(struct img_type *img,
+		       void __attribute__ ((__unused__)) *data,
+		       script_fn scriptfn)
 {
-	script_fn scriptfn;
 	struct flash_description *flash = get_flash_info();
 	libubi_t libubi = flash->libubi;
 	int num, count = 0;
@@ -464,11 +467,6 @@ static int swap_volume(struct img_type *img, void *data)
 	char masternode[UBI_MAX_VOLUME_NAME+1];
 	struct ubi_rnvol_req rnvol;
 	int ret = -1;
-
-	if (!data)
-		return -EINVAL;
-
-	scriptfn = *(script_fn *)data;
 
 	/*
 	 * Call only in case of postinstall

--- a/handlers/ucfw_handler.c
+++ b/handlers/ucfw_handler.c
@@ -498,7 +498,8 @@ static int get_gpio_from_property(struct dict_list *prop, struct mode_setup *gpi
 }
 
 static int install_uc_firmware_image(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	struct handler_priv hnd_data;
 	struct dict_list *properties;

--- a/handlers/uniqueuuid_handler.c
+++ b/handlers/uniqueuuid_handler.c
@@ -28,7 +28,8 @@
 void uniqueuuid_handler(void);
 
 static int uniqueuuid(struct img_type *img,
-	void __attribute__ ((__unused__)) *data)
+	void __attribute__ ((__unused__)) *data,
+	script_fn __attribute__ ((__unused__)) scriptfn)
 {
 	struct dict_list *uuids;
 	struct dict_list_elem *uuid;

--- a/include/handler.h
+++ b/include/handler.h
@@ -33,7 +33,7 @@ typedef enum {
 			BOOTLOADER_HANDLER | PARTITION_HANDLER | \
 			NO_DATA_HANDLER)
 
-typedef int (*handler)(struct img_type *img, void *data);
+typedef int (*handler)(struct img_type *img, void *data, script_fn scriptfn);
 struct installer_handler{
 	char	desc[64];
 	handler installer;


### PR DESCRIPTION
The second argument to a handlers is normally its opaque data pointer,
but for script handlers it's a pointer to the script_fn (PREINSTALL or
POSTINSTALL) indicating which phase it is being called for.

The Lua handler wrapper code always needs its opaque data pointer,
so it currently can't be used to implement script handlers.

* Replace the two uses of the data parameter with two separate
  parameters
* Add support for script handlers in the Lua handler wrapper
* Add a missing definition to the Lua bindings that can be useful for
  script handlers