### PR TITLE
Update channel_curl.c

### DIFF
--- a/corelib/channel_curl.c
+++ b/corelib/channel_curl.c
@@ -440,8 +440,8 @@ static int channel_callback_xferinfo(void *p, curl_off_t dltotal, curl_off_t dln
 		data->percent = percent;
 
 	DEBUG("Downloaded %d%% (%lu of %lu kB)", percent,
-	      (unsigned long)dlnow / 1024,
-	      (unsigned long)dltotal / 1024);
+		(unsigned long)dlnow / 1024,
+		(unsigned long)dltotal / 1024);
 	swupdate_download_update(percent, dltotal);
 
 	return 0;

--- a/corelib/channel_curl.c
+++ b/corelib/channel_curl.c
@@ -439,7 +439,9 @@ static int channel_callback_xferinfo(void *p, curl_off_t dltotal, curl_off_t dln
 	else
 		data->percent = percent;
 
-	DEBUG("Downloaded %d%% (%lu of %lu kB).", percent, dlnow / 1024, dltotal / 1024);
+	DEBUG("Downloaded %d%% (%lu of %lu kB)", percent,
+	      (unsigned long)dlnow / 1024,
+	      (unsigned long)dltotal / 1024);
 	swupdate_download_update(percent, dltotal);
 
 	return 0;


### PR DESCRIPTION
Convert download statistics to `unsigned long` before division to avoid data loss and wrong progress report.
Also remove final `.` since its not desirable in the final logs.

Before:
```
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 1% (1 of 880 kB).
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 2% (1 of 1744 kB).
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 3% (1 of 2608 kB).
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 4% (1 of 3472 kB).
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 5% (1 of 4352 kB).
```
After
```
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 1% (880 of 86760 kB)
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 2% (1744 of 86760 kB)
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 3% (2608 of 86760 kB)
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 4% (3472 of 86760 kB)
[DEBUG ] : SWUPDATE running :  [channel_callback_xferinfo] : Downloaded 5% (4352 of 86760 kB)

```