### PR TITLE
readback handler: use size_t for partition size

### DIFF
--- a/handlers/readback_handler.c
+++ b/handlers/readback_handler.c
@@ -52,7 +52,7 @@ static int readback_postinst(struct img_type *img)
 	}
 
 	/* Get property: partition size */
-	unsigned int size = 0;
+	size_t size = 0;
 	char *value = dict_get_value(&img->properties, "size");
 	if (value) {
 		size = strtoul(value, NULL, 10);
@@ -83,7 +83,7 @@ static int readback_postinst(struct img_type *img)
 			close(fdin);
 			return -EFAULT;
 		}
-		TRACE("Partition size: %u", size);
+		TRACE("Partition size: %zu", size);
 	}
 
 	/* 


### PR DESCRIPTION
The readback handler was failing with partitions greater than or equal to 4 GB in size on architectures with 32-bit ints