### PR TITLE
core/bootloader.c: fix build without reallocarray

### DIFF
--- a/core/bootloader.c
+++ b/core/bootloader.c
@@ -25,7 +25,7 @@ static unsigned int num_available = 0;
 
 int register_bootloader(const char *name, bootloader *bl)
 {
-	entry *tmp = reallocarray(available, num_available + 1, sizeof(entry));
+	entry *tmp = realloc(available, (num_available + 1) * sizeof(entry));
 	if (!tmp) {
 		return -ENOMEM;
 	}


### PR DESCRIPTION
Use `realloc` instead of `reallocarray` to avoid the following build failure with uclibc raised since version 2022.05 and https://github.com/sbabic/swupdate/commit/b8897ed695e1cd954859142b14ec8546d2e7994a:

```
/nvmedata/autobuild/instance-0/output-1/host/lib/gcc/microblaze-buildroot-linux-uclibc/10.3.0/../../../../microblaze-buildroot-linux-uclibc/bin/ld: core/built-in.o: in function `register_bootloader':
(.text.register_bootloader+0x30): undefined reference to `reallocarray'
```

Fixes:
 - http://autobuild.buildroot.org/results/7208e8189b4a6f35aaa4ed7777ecdd37421a7c7f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>