### PR TITLE
Fix grubenv parsing with # WARNING: Do not edit... line

### DIFF
--- a/bootloader/grub.h
+++ b/bootloader/grub.h
@@ -18,6 +18,7 @@
 
 #define GRUBENV_SIZE 1024 /* bytes */
 #define GRUBENV_HEADER "# GRUB Environment Block\n"
+#define GRUBENV_HEADER_WARNING "# WARNING"
 #define GRUBENV_DEFAULT_PATH "/boot/efi/EFI/BOOT/grub/grubenv"
 
 #ifdef CONFIG_GRUBENV_PATH


### PR DESCRIPTION
grubenv created with grub-editenv can have a second header line:
`# WARNING: Do not edit this file by tools other than grub-editenv!!!`
This line needs to be skipped.