### PR TITLE
ipc: runtime configurable socket paths

### DIFF
--- a/doc/source/swupdate.rst
+++ b/doc/source/swupdate.rst
@@ -204,6 +204,17 @@ copies. Not all handlers support to stream directly into the target.
 Streaming with zero-copy is enabled by setting the flag "installed-directly"
 in the description of the single image.
 
+Multiple swupdate instances supported
+-------------------------------------
+
+Multiple swupdate instances can run in a single system. In order to make this possible
+it is necessary to customize the control and progress socket paths. This can be achieved
+at runtime by setting the environment variables ``SOCKET_CTRL_PATH`` and
+``SOCKET_PROGRESS_PATH``.
+
+These runtime variables will override the default value and the compile-time values set for
+these socket files.
+
 Configuration and build
 =======================
 

--- a/ipc/network_ipc.c
+++ b/ipc/network_ipc.c
@@ -27,6 +27,11 @@ static char* SOCKET_CTRL_PATH = NULL;
 #define SOCKET_CTRL_DEFAULT  "sockinstctrl"
 
 char *get_ctrl_socket(void) {
+	const char *socket_ctrl_path = getenv("SOCKET_CTRL_PATH");
+	if (socket_ctrl_path) {
+		return (char *)socket_ctrl_path;
+	}
+
 	if (!SOCKET_CTRL_PATH || !strlen(SOCKET_CTRL_PATH)) {
 		const char *tmpdir = getenv("TMPDIR");
 		if (!tmpdir)

--- a/ipc/progress_ipc.c
+++ b/ipc/progress_ipc.c
@@ -25,6 +25,11 @@ char *SOCKET_PROGRESS_PATH = NULL;
 #define SOCKET_PROGRESS_DEFAULT  "swupdateprog"
 
 char *get_prog_socket(void) {
+	const char *socket_progress_path = getenv("SOCKET_PROGRESS_PATH");
+	if (socket_progress_path) {
+		return (char *)socket_progress_path;
+	}
+
 	if (!SOCKET_PROGRESS_PATH || !strlen(SOCKET_PROGRESS_PATH)) {
 		const char *tmpdir = getenv("TMPDIR");
 		if (!tmpdir)


### PR DESCRIPTION
if multiple instances of swupdate are to be run on a single system socket paths need to be configurable at runtime. This modification allows the user to select socket paths at runtime using environment variables SOCKET_CTRL_PATH and SOCKET_PROGRESS_PATH.

Signed-off-by: Xabier Marquiegui <reibax@gmail.com>