### PR TITLE
feat: add route for sw update client python tool

### DIFF
--- a/tools/python/swupdateclient/README.md
+++ b/tools/python/swupdateclient/README.md
@@ -21,12 +21,12 @@ pipenv install
 
 ### pip
 ```
-swupdateclient <path-to-swu> <host_name> [port]
+swupdateclient <path-to-swu> <host_name> [port] [route]
 ```
 
 ### pipenv
 ```
-pipenv run swupdateclient <path-to-swu> <host_name> [port]
+pipenv run swupdateclient <path-to-swu> <host_name> [port] [route]
 ```
 
 

--- a/tools/python/swupdateclient/setup.py
+++ b/tools/python/swupdateclient/setup.py
@@ -4,14 +4,14 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='swupdateclient',
-    version='0.1',
+    name="swupdateclient",
+    version="0.1",
     packages=find_packages(),
-    url='https://github.com/sbabic/swupdate/tree/master/tools/python/swupdateclient',
-    license='GPL-2.0-only',
-    author='Stefano Babic',
-    author_email='stefano.babic@swupdate.org',
-    description='Python Client to update SWUpdate based devices',
+    url="https://github.com/sbabic/swupdate/tree/master/tools/python/swupdateclient",
+    license="GPL-2.0-only",
+    author="Stefano Babic",
+    author_email="stefano.babic@swupdate.org",
+    description="Python Client to update SWUpdate based devices",
     entry_points={
         "console_scripts": [
             "swupdateclient=swupdateclient.main:main",

--- a/tools/python/swupdateclient/swupdateclient/main.py
+++ b/tools/python/swupdateclient/swupdateclient/main.py
@@ -46,10 +46,12 @@ class ColorFormatter(logging.Formatter):
     }
 
     def format(self, record):
-        return logging.Formatter(colored(
-            "%(levelname)s:%(name)s:%(message)s",
-            self.COLORS[record.levelno],
-            attrs=self.ATTRIBUTES[record.levelno])
+        return logging.Formatter(
+            colored(
+                "%(levelname)s:%(name)s:%(message)s",
+                self.COLORS[record.levelno],
+                attrs=self.ATTRIBUTES[record.levelno],
+            )
         ).format(record)
 
 
@@ -59,7 +61,15 @@ class SWUpdater:
     url_upload = "http://{}:{}{}/upload"
     url_status = "ws://{}:{}{}/ws"
 
-    def __init__(self, path_image, host_name, port=8080, route="", logger=None, log_level=logging.DEBUG):
+    def __init__(
+        self,
+        path_image,
+        host_name,
+        port=8080,
+        route="",
+        logger=None,
+        log_level=logging.DEBUG,
+    ):
         self._image = path_image
         self._host_name = host_name
         self._port = port
@@ -99,9 +109,7 @@ class SWUpdater:
                     if data["type"] != "message":
                         continue
 
-                    self._logger.log(
-                        LOGGING_MAPPING[data["level"]],
-                        data["text"])
+                    self._logger.log(LOGGING_MAPPING[data["level"]], data["text"])
 
                     if "SWUPDATE successful" in data["text"]:
                         return True
@@ -130,8 +138,8 @@ class SWUpdater:
 
             if response.status_code != 200:
                 self._logger.error(
-                    "Cannot upload software image: %s",
-                    response.status_code)
+                    "Cannot upload software image: %s", response.status_code
+                )
                 return False
 
             self._logger.info(
@@ -168,7 +176,7 @@ class SWUpdater:
         return asyncio.run(self.start_tasks(timeout))
 
 
-def client (args: List[str]) -> None:
+def client(args: List[str]) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("swu_file", help="Path to swu image")
     parser.add_argument("host_name", help="Host name")
@@ -178,7 +186,7 @@ def client (args: List[str]) -> None:
         help="Name of the API route (e.g. /ROUTE)",
         type=str,
         default="",
-        nargs="?"
+        nargs="?",
     )
     parser.add_argument(
         "--timeout",
@@ -188,13 +196,20 @@ def client (args: List[str]) -> None:
         nargs="?",
     )
     parser.add_argument(
-        "--log-level", help="change log level (error, info, warning, debug)",
-        type=str, metavar="[LEVEL]",
-        choices=["error", "info", "warning", "debug"], default="debug"
+        "--log-level",
+        help="change log level (error, info, warning, debug)",
+        type=str,
+        metavar="[LEVEL]",
+        choices=["error", "info", "warning", "debug"],
+        default="debug",
     )
     parser.add_argument(
-        "--color", help="colorize messages (auto, always or never)", type=str,
-        metavar="[WHEN]", choices=["auto", "always", "never"], default="auto"
+        "--color",
+        help="colorize messages (auto, always or never)",
+        type=str,
+        metavar="[WHEN]",
+        choices=["auto", "always", "never"],
+        default="auto",
     )
 
     args = parser.parse_args()
@@ -210,11 +225,14 @@ def client (args: List[str]) -> None:
         args.host_name,
         args.port,
         args.route,
-        log_level=args.log_level.upper())
+        log_level=args.log_level.upper(),
+    )
     updater.update(timeout=args.timeout)
+
 
 def main():
     client(sys.argv[1:])
+
 
 if __name__ == "__main__":
     main()

--- a/tools/python/swupdateclient/swupdateclient/main.py
+++ b/tools/python/swupdateclient/swupdateclient/main.py
@@ -56,13 +56,14 @@ class ColorFormatter(logging.Formatter):
 class SWUpdater:
     """Python helper class for SWUpdate"""
 
-    url_upload = "http://{}:{}/upload"
-    url_status = "ws://{}:{}/ws"
+    url_upload = "http://{}:{}{}/upload"
+    url_status = "ws://{}:{}{}/ws"
 
-    def __init__(self, path_image, host_name, port=8080, logger=None, log_level=logging.DEBUG):
+    def __init__(self, path_image, host_name, port=8080, route="", logger=None, log_level=logging.DEBUG):
         self._image = path_image
         self._host_name = host_name
         self._port = port
+        self._route = route
         if logger is not None:
             self._logger = logger
         else:
@@ -76,7 +77,7 @@ class SWUpdater:
         self._logger.info("Waiting for messages on websocket connection")
         try:
             async with websockets.connect(
-                self.url_status.format(self._host_name, self._port)
+                self.url_status.format(self._host_name, self._port, self._route)
             ) as websocket:
                 while True:
                     try:
@@ -112,7 +113,7 @@ class SWUpdater:
 
     def sync_upload(self, swu_file, timeout):
         return requests.post(
-            self.url_upload.format(self._host_name, self._port),
+            self.url_upload.format(self._host_name, self._port, self._route),
             files={"file": swu_file},
             headers={"Cache-Control": "no-cache"},
             timeout=timeout,
@@ -173,6 +174,13 @@ def client (args: List[str]) -> None:
     parser.add_argument("host_name", help="Host name")
     parser.add_argument("port", help="Port", type=int, default=8080, nargs="?")
     parser.add_argument(
+        "route",
+        help="Name of the API route (e.g. /ROUTE)",
+        type=str,
+        default="",
+        nargs="?"
+    )
+    parser.add_argument(
         "--timeout",
         help="Timeout for the whole swupdate process",
         type=int,
@@ -201,6 +209,7 @@ def client (args: List[str]) -> None:
         args.swu_file,
         args.host_name,
         args.port,
+        args.route,
         log_level=args.log_level.upper())
     updater.update(timeout=args.timeout)
 


### PR DESCRIPTION
if the update server is behind a reverse proxy a route is needed. The route should be optional and also work with web-sever without an additional route.

Usage:
```shell
python ./main.py ./swu.swu 192.168.0.100 80 /update
```