### PR TITLE
containers: let DOCKER select CHANNEL_CURL

### DIFF
--- a/containers/Config.in
+++ b/containers/Config.in
@@ -8,6 +8,7 @@ config DOCKER
 	bool "Support Docker REST API"
 	depends on HAVE_LIBCURL
 	default n
+	select CHANNEL_CURL
 	help
 	  Add native support for container. This implements a part of the REST API,
 	  what is required to install new images.


### PR DESCRIPTION
Get rid of the following build error:
docker.c:(.text.docker_prepare_channel+0x20): undefined reference to `channel_new'