### PR TITLE
fix: error when using fseek on 32-bit system

### DIFF
--- a/handlers/rdiff_handler.c
+++ b/handlers/rdiff_handler.c
@@ -71,7 +71,7 @@ static rs_result base_file_read_cb(void *fp, rs_long_t pos, size_t *len, void **
 {
 	FILE *f = (FILE *)fp;
 
-	if (fseek(f, pos, SEEK_SET) != 0) {
+	if (fseeko64(f, pos, SEEK_SET) != 0) {
 		ERROR("Error seeking rdiff base file: %s", strerror(errno));
 		return RS_IO_ERROR;
 	}


### PR DESCRIPTION
When running on an armhf system, if the basefile size exceeds the maximum value of uin32, the program will report an error: `Error seeking rdiff base file: Invalid argument`