### PR TITLE
fix: missing include in copy_handler.c

### DIFF
--- a/handlers/copy_handler.c
+++ b/handlers/copy_handler.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier:     GPL-2.0-only
  */
 
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>


### PR DESCRIPTION
pipe() and close() function calls are forward-declared in unistd.h.