### PR TITLE
notifier: workaround for sscanf format mismatch

### DIFF
--- a/core/notifier.c
+++ b/core/notifier.c
@@ -537,8 +537,8 @@ void notify_init(void)
 	 */
 	if (sd_booted() && getenv("JOURNAL_STREAM") != NULL) {
 		dev_t device;
-		ino_t inode;
-		if (sscanf(getenv("JOURNAL_STREAM"), "%" SCNu64 ":%lu", &device, &inode) == 2) {
+		unsigned long long inode;
+		if (sscanf(getenv("JOURNAL_STREAM"), "%" SCNu64 ":%llu", &device, &inode) == 2) {
 			struct stat statbuffer;
 			if (fstat(fileno(stderr), &statbuffer) == 0) {
 				if (inode == statbuffer.st_ino && device == statbuffer.st_dev) {


### PR DESCRIPTION
ino_t is either 'unsigned long' or 'unsigned long long' (depending on the platform and the C library version). As the C library doesn't provide a printf/scanf 'conversion specifier' for ino_t, we shouldn't pass a pointer of this type to sscanf.