### PR TITLE
[PATCH] mongoose, progress: resolve 'Restart System' from web UI IPC event

### DIFF
--- a/mongoose/mongoose_interface.c
+++ b/mongoose/mongoose_interface.c
@@ -344,8 +344,12 @@ static const char *get_source_string(unsigned int source)
 
 static void restart_handler(struct mg_connection *nc, void *ev_data)
 {
-	struct mg_http_message *hm = (struct mg_http_message *) ev_data;
-	ipc_message msg = {};
+	struct mg_http_message* hm = (struct mg_http_message*)ev_data;
+	ipc_message msg;
+
+	size_t size = sizeof(msg.data.procmsg.buf);
+	snprintf(msg.data.procmsg.buf, size, "{\"reboot\": \"true\"}");
+	msg.data.procmsg.len = strnlen(msg.data.procmsg.buf, size);
 
 	if(mg_strcasecmp(hm->method, mg_str("POST")) != 0) {
 		mg_http_reply(nc, 405, "", "%s", "Method Not Allowed\n");

--- a/tools/swupdate-progress.c
+++ b/tools/swupdate-progress.c
@@ -442,6 +442,9 @@ int main(int argc, char **argv)
 			break;
 		case DONE:
 			fprintf(stdout, "\nDONE.\n\n");
+			if (opt_r && strcasestr(msg.info, "\"reboot\": \"true\"")) {
+				reboot_device();
+			}
 			break;
 		case PROGRESS:
 			/*


### PR DESCRIPTION
**GitHub PR of the `[PATCH] mongoose, progress: resolve 'Restart System' from web UI IPC event` mailing list.**

---

If 'swupdate-progress' service is used with its '-r' reboot mode, and if 'globals : { postupdatecmd = "/sbin/reboot"; };' is not used, the 'Restart System' button on the SWUpdate web UI has no effect.

An IPC event 'DONE' is sent upon '/restart' endpoint event, however the 'swupdate-progress' only prints a log without rebooting.

Add a specific message info to request a reboot through IPC 'DONE'. 

---

Related older discussions:
* 2021, Stefano BABIC: https://groups.google.com/g/swupdate/c/SeLdhS8Y8yw/m/JLJT0kpkAwAJ
* 2021, Stefan HERBRECHTSMEIER: https://groups.google.com/g/swupdate/c/SeLdhS8Y8yw/m/JLJT0kpkAwAJ